### PR TITLE
CLI Arg to Specify logs folder

### DIFF
--- a/src/cloud_courier/cli.py
+++ b/src/cloud_courier/cli.py
@@ -31,3 +31,8 @@ _ = parser.add_argument(
 )
 _ = parser.add_argument("--log-level", type=str, default="INFO", help="The log level to use for the logger")
 _ = parser.add_argument("--log-folder", type=str, help="The folder to write logs to")
+_ = parser.add_argument(
+    "--no-console-logging",
+    action="store_true",
+    help="Suppress console logging. Useful for some SSM Run commands.",
+)

--- a/src/cloud_courier/cli.py
+++ b/src/cloud_courier/cli.py
@@ -30,3 +30,4 @@ _ = parser.add_argument(
     default=5,
 )
 _ = parser.add_argument("--log-level", type=str, default="INFO", help="The log level to use for the logger")
+_ = parser.add_argument("--log-folder", type=str, help="The folder to write logs to")

--- a/src/cloud_courier/logger_config.py
+++ b/src/cloud_courier/logger_config.py
@@ -7,7 +7,9 @@ import structlog
 SUBSYSTEM_NAME = "courier"
 
 
-def configure_logging(log_filename_prefix: str = "logs/cloud-courier-", log_level: str = "INFO"):
+def configure_logging(
+    *, log_filename_prefix: str = "logs/cloud-courier-", log_level: str = "INFO", suppress_console_logging: bool = False
+):
     """Configure structlog to output both to the console and JSON to a file.
 
     This also configures stdlib logging to also use the same structlog formatters using details found here.
@@ -82,7 +84,9 @@ def configure_logging(log_filename_prefix: str = "logs/cloud-courier-", log_leve
         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
         structlog.dev.ConsoleRenderer(colors=True),
     ]
-
+    handlers = ["file"]
+    if not suppress_console_logging:
+        handlers.append("default")
     dictConfig(
         {
             "version": 1,
@@ -114,7 +118,7 @@ def configure_logging(log_filename_prefix: str = "logs/cloud-courier-", log_leve
             },
             "loggers": {
                 "": {
-                    "handlers": ["default", "file"],
+                    "handlers": handlers,
                     "level": log_level,
                     "propagate": True,
                 },

--- a/src/cloud_courier/main.py
+++ b/src/cloud_courier/main.py
@@ -311,7 +311,9 @@ def entrypoint(argv: Sequence[str]) -> int:
         if cli_args.log_folder is not None:
             log_folder = Path(cli_args.log_folder)
         configure_logging(
-            log_level=cli_args.log_level, log_filename_prefix=str(log_folder / "cloud-courier-")
+            log_level=cli_args.log_level,
+            log_filename_prefix=str(log_folder / "cloud-courier-"),
+            suppress_console_logging=bool(cli_args.no_console_logging),
         )  # TODO: move the logs folder into ProgramData by default
         logger.info('Starting "cloud-courier"')
         boto_session = (

--- a/src/cloud_courier/main.py
+++ b/src/cloud_courier/main.py
@@ -307,7 +307,12 @@ def entrypoint(argv: Sequence[str]) -> int:
         except argparse.ArgumentError:
             logger.exception("Error parsing command line arguments")
             return 2  # this is the exit code that is normally returned when exit_on_error=True for argparse
-        configure_logging(log_level=cli_args.log_level)  # TODO: move the logs folder into ProgramData by default
+        log_folder = Path("logs")
+        if cli_args.log_folder is not None:
+            log_folder = Path(cli_args.log_folder)
+        configure_logging(
+            log_level=cli_args.log_level, log_filename_prefix=str(log_folder / "cloud-courier-")
+        )  # TODO: move the logs folder into ProgramData by default
         logger.info('Starting "cloud-courier"')
         boto_session = (
             boto3.Session() if cli_args.use_generic_boto_session else create_boto_session(cli_args.aws_region)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -79,7 +79,9 @@ class TestArgParse(MainMixin):
             == 0
         )
 
-        spied_configure_logging.assert_called_once_with(log_level=expected_log_level, log_filename_prefix=ANY)
+        spied_configure_logging.assert_called_once_with(
+            log_level=expected_log_level, log_filename_prefix=ANY, suppress_console_logging=ANY
+        )
 
     def test_Given_log_folder_specified__Then_log_folder_passed_to_configure_logging(self, mocker: MockerFixture):
         spied_configure_logging = mocker.spy(main, "configure_logging")
@@ -98,7 +100,30 @@ class TestArgParse(MainMixin):
         )
 
         spied_configure_logging.assert_called_once_with(
-            log_filename_prefix=str(Path(expected_log_folder) / "cloud-courier-"), log_level=ANY
+            log_filename_prefix=str(Path(expected_log_folder) / "cloud-courier-"),
+            log_level=ANY,
+            suppress_console_logging=False,
+        )
+
+    def test_Given_suppress_console_logging_specified__Then_kwarg_passed_to_configure_logging(
+        self, mocker: MockerFixture
+    ):
+        spied_configure_logging = mocker.spy(main, "configure_logging")
+
+        assert (
+            entrypoint(
+                [
+                    f"--stop-flag-dir={self.flag_file_dir}",
+                    "--immediate-shut-down",
+                    "--aws-region=us-east-1",
+                    "--no-console-logging",
+                ]
+            )
+            == 0
+        )
+
+        spied_configure_logging.assert_called_once_with(
+            log_filename_prefix=ANY, log_level=ANY, suppress_console_logging=True
         )
 
 


### PR DESCRIPTION
 ## Why is this change necessary?
Without this, when launched from an SSM Command, the logs are very hard to find.


 ## How does this change address the issue?
Adds command line arguments to specify the log folder and also suppress console logging


 ## What side effects does this change have?
None


 ## How is this change tested?
Unit and live when launched from SSM Command
