### PR TITLE
Minor changes Apple silicon dev

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   devcontainer:
+    platform: linux/amd64
     build:
       context: .
       args:

--- a/.gitignore
+++ b/.gitignore
@@ -76,4 +76,8 @@ dist
 *.log
 **/logs/log*.txt
 
+# macOS dev cleanliness
+*.DS_Store
+.DS_Store
+
 # Ignores specific to this repository


### PR DESCRIPTION
 ## Link to Issue or Message thread
(No explicit issue, describing issue below)


 ## Why is this change necessary?
Makes it easier to onboard devs using Docker Desktop on Apple Silicon devices (even when using the dev-containers). 


 ## How does this change address the issue?
Was a necesarry change in my hands to get started with the dev-container . 


 ## What side effects does this change have?
There may be subtleties with how it intersects with cloud deployment targets (in other repos?), if the deployment targets do not use amd64 platform. I think amd64 is a reasonable explicit default for cloud deployment, because I'd assume it's 99% of available cloud resources even with the impressive efficiency advantages of arm cloud resources.


 ## How is this change tested?
I haven't tested this change beyond my 1st pass through. 

 ## Other
Feedback on any cleanliness from commit messages to PR, always good!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Configured the development container to target the linux/amd64 platform for consistent local setups.
  - Added ignore patterns for macOS system files (e.g., .DS_Store) to prevent committing OS artifacts.
  - Changes are limited to development workflow and repository hygiene; no impact on application behavior or production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->